### PR TITLE
Adjustments to the markup of a few tokens

### DIFF
--- a/R/highlight.R
+++ b/R/highlight.R
@@ -19,8 +19,6 @@
   LEFT_ASSIGN          = 'kwb', # assignment
   EQ_ASSIGN            = 'kwb',
   RIGHT_ASSIGN         = 'kwb',
-  EQ_FORMALS           = 'kwb',
-  EQ_SUB               = 'kwb',
   setNames(rep('opt', length(.operators)), .operators),
   setNames(rep('kwa', length(.keywords)), .keywords),
   STANDARD             = 'std' # everything else

--- a/tests/testit/test-hilight.R
+++ b/tests/testit/test-hilight.R
@@ -23,7 +23,7 @@ assert(
   'hi_latex() preserves blank lines',
   identical(hi_latex(c('1+1','','foo(x=3) # comm')), c(
     '\\hlnum{1}\\hlopt{+}\\hlnum{1}\n',
-    '\\hlkwd{foo}\\hlstd{(}\\hlkwc{x}\\hlkwb{=}\\hlnum{3}\\hlstd{)} \\hlcom{# comm}'
+    '\\hlkwd{foo}\\hlstd{(}\\hlkwc{x}\\hlstd{=}\\hlnum{3}\\hlstd{)} \\hlcom{# comm}'
   ))
 )
 


### PR DESCRIPTION
- Markup `=` in the same way in `x = 1`, `function (x=1)` and `f(x=1)`;
- Recognize operators `::` and `:::`;
- Treat `NULL` like `NA` and `TRUE` rather than keywords.

Besides,
- `SLOT` is currently formatted like formal argument names. Is this intended? How about  leaving it out like `SYMBOL`, e.g. in `foo$bar`?
- Would it look better if we supplement `.operators` with (some of) `[`, `]`, `LBB`, `(`, `)`?
