### PR TITLE
Update highlight.R to use same syntax as AS highlight

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,4 +24,4 @@ URL: https://github.com/yihui/highr
 BugReports: https://github.com/yihui/highr/issues
 VignetteBuilder: knitr
 Encoding: UTF-8
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN highr VERSION 0.11
 
+- Changed `\hlstr` to `\hlsng` and `\hlstd` to `\hldef` (thanks, @dcser123, #11).
+
 # CHANGES IN highr VERSION 0.10
 
 - The minimal R version required is 3.3.0 now.

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -78,7 +78,7 @@ merge_cmd = function(pdata, cmd) {
 #'
 #' For the \code{markup} data frame, the first column is put before the R
 #' tokens, and the second column is behind; the row names of the data frame must
-#' be the R token names; a special row is named \code{STANDARD}, which contains
+#' be the R token names; a special row is named \code{DEFAULT}, which contains
 #' the markup for the standard tokens (i.e. those that do not need to be
 #' highlighted); if missing, the built-in data frames \code{highr:::cmd_latex}
 #' and \code{highr:::cmd_html} will be used.
@@ -131,7 +131,7 @@ hilight = function(code, format = c('latex', 'html'), markup, prompt = FALSE, fa
     (if (fallback) hi_naive else hilight_one)(code, format, markup, escape_fun)
   )
   p1 = escape_fun(getOption('prompt')); p2 = escape_fun(getOption('continue'))
-  std = unlist(markup['STANDARD', ])
+  std = unlist(markup['DEFAULT', ])
   if (!any(is.na(std))) {
     p1 = paste0(std[1], p1, std[2]); p2 = paste0(std[1], p2, std[2])
   }

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -10,7 +10,7 @@
 .cmd.list = sort(c(
   NUM_CONST            = 'num', # numbers
   SYMBOL_FUNCTION_CALL = 'kwd', # function calls
-  STR_CONST            = 'str', # character strings
+  STR_CONST            = 'sng', # character strings
   COMMENT              = 'com', # comment
   SYMBOL_FORMALS       = 'kwc', # function(formals)
   SYMBOL_SUB           = 'kwc', # FUN(args)
@@ -20,7 +20,7 @@
   RIGHT_ASSIGN         = 'kwb',
   setNames(rep('opt', length(.operators)), .operators),
   setNames(rep('kwa', length(.keywords)), .keywords),
-  STANDARD             = 'std' # everything else
+  DEFAULT              = 'def' # everything else
 ))
 
 cmd_latex = data.frame(
@@ -38,9 +38,9 @@ cmd_latex = data.frame(
 )
 
 .cmd.pandoc = c(
-  num = 'DecValTok', kwd = 'KeywordTok', str = 'StringTok', com = 'CommentTok',
+  num = 'DecValTok', kwd = 'KeywordTok', sng = 'StringTok', com = 'CommentTok',
   kwc = 'DataTypeTok', kwb = 'NormalTok', opt = 'NormalTok', kwa = 'NormalTok',
-  std = 'NormalTok'
+  def = 'NormalTok'
 )
 
 cmd_pandoc_latex = data.frame(
@@ -61,9 +61,9 @@ cmd_html = data.frame(
 merge_cmd = function(pdata, cmd) {
   res = cmd[pdata$token, ]
   idx = is.na(res[, 1])
-  res[idx, 1] = cmd['STANDARD', 1]
-  res[idx, 2] = cmd['STANDARD', 2]
-  res[is.na(res)] = '' # if STANDARD is undefined in the markup data frame
+  res[idx, 1] = cmd['DEFAULT', 1]
+  res[idx, 2] = cmd['DEFAULT', 2]
+  res[is.na(res)] = '' # if DEFAULT is undefined in the markup data frame
   res
 }
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ a <- 1 # something
 into LaTeX code
 
 ```latex
-\hlstd{a} \hlkwb{<-} \hlnum{1} \hlcom{\# something}
+\hldef{a} \hlkwb{<-} \hlnum{1} \hlcom{\# something}
 ```
 
 or HTML code

--- a/man/hilight.Rd
+++ b/man/hilight.Rd
@@ -49,7 +49,7 @@ The two functions \code{hi_latex} and \code{hi_html} are wrappers of
 \details{
 For the \code{markup} data frame, the first column is put before the R
 tokens, and the second column is behind; the row names of the data frame must
-be the R token names; a special row is named \code{STANDARD}, which contains
+be the R token names; a special row is named \code{DEFAULT}, which contains
 the markup for the standard tokens (i.e. those that do not need to be
 highlighted); if missing, the built-in data frames \code{highr:::cmd_latex}
 and \code{highr:::cmd_html} will be used.

--- a/tests/testit/test-hilight.R
+++ b/tests/testit/test-hilight.R
@@ -5,17 +5,17 @@ assert(
   hi_latex('1+1') == '\\hlnum{1}\\hlopt{+}\\hlnum{1}',
   hi_latex('  1 +    1') == '  \\hlnum{1} \\hlopt{+}    \\hlnum{1}',
   identical(hi_latex(c('  if (TRUE ){', 'foo && bar}')), c(
-    '  \\hlkwa{if} \\hlstd{(}\\hlnum{TRUE} \\hlstd{)\\{}',
-    '\\hlstd{foo} \\hlopt{&&} \\hlstd{bar\\}}'
+    '  \\hlkwa{if} \\hldef{(}\\hlnum{TRUE} \\hldef{)\\{}',
+    '\\hldef{foo} \\hlopt{&&} \\hldef{bar\\}}'
   ))
 )
 
 assert(
   'hi_latex() works with prompts',
-  hi_latex('1+1', prompt=TRUE) == '\\hlstd{> }\\hlnum{1}\\hlopt{+}\\hlnum{1}',
+  hi_latex('1+1', prompt=TRUE) == '\\hldef{> }\\hlnum{1}\\hlopt{+}\\hlnum{1}',
   identical(hi_latex(c('  if (TRUE ){', 'foo && bar}'), prompt = TRUE), paste(
-    '\\hlstd{> }  \\hlkwa{if} \\hlstd{(}\\hlnum{TRUE} \\hlstd{)\\{}',
-    '\\hlstd{+ }\\hlstd{foo} \\hlopt{&&} \\hlstd{bar\\}}', sep = '\n'
+    '\\hldef{> }  \\hlkwa{if} \\hldef{(}\\hlnum{TRUE} \\hldef{)\\{}',
+    '\\hldef{+ }\\hldef{foo} \\hlopt{&&} \\hldef{bar\\}}', sep = '\n'
   ))
 )
 
@@ -23,7 +23,7 @@ assert(
   'hi_latex() preserves blank lines',
   identical(hi_latex(c('1+1','','foo(x=3) # comm')), c(
     '\\hlnum{1}\\hlopt{+}\\hlnum{1}\n',
-    '\\hlkwd{foo}\\hlstd{(}\\hlkwc{x}\\hlstd{=}\\hlnum{3}\\hlstd{)} \\hlcom{# comm}'
+    '\\hlkwd{foo}\\hldef{(}\\hlkwc{x}\\hldef{=}\\hlnum{3}\\hldef{)} \\hlcom{# comm}'
   ))
 )
 
@@ -31,7 +31,7 @@ assert(
   'the fallback method recognizes comments, functions and strings',
   identical(hi_latex('1+1 # a comment', fallback = TRUE), '1+1 \\hlcom{# a comment}'),
   identical(hi_latex('paste("STRING", \'string\')', fallback = TRUE),
-            '\\hlkwd{paste}(\\hlstr{"STRING"}, \\hlstr{\'string\'})')
+            '\\hlkwd{paste}(\\hlsng{"STRING"}, \\hlsng{\'string\'})')
 )
 
 assert(
@@ -47,7 +47,7 @@ assert(
 
 assert(
   'the right arrow -> is preserved',
-  identical(hi_latex('1 ->x # foo'), '\\hlnum{1} \\hlkwb{->}\\hlstd{x} \\hlcom{# foo}')
+  identical(hi_latex('1 ->x # foo'), '\\hlnum{1} \\hlkwb{->}\\hldef{x} \\hlcom{# foo}')
 )
 
 assert(

--- a/vignettes/highr-internals.Rmd
+++ b/vignettes/highr-internals.Rmd
@@ -71,7 +71,7 @@ paste all pieces together (suppose we highlight for LaTeX):
 m = highr:::cmd_latex[d$token, ]
 cbind(d, m)
 # use standard markup if tokens do not exist in the table
-m[is.na(m[, 1]), ] = highr:::cmd_latex['STANDARD', ]
+m[is.na(m[, 1]), ] = highr:::cmd_latex['DEFAULT', ]
 paste(s, m[, 1], d$text, m[, 2], sep = '', collapse = '')
 ```
 


### PR DESCRIPTION
I believe that AS highlight has been updated and the naming uses \hldef for the standard or default and \hlsng for strings now. On the same lines as this [SO](https://stackoverflow.com/questions/71280893/knitr-rnw-highr-error-in-def-sng-color-not-being-created) post. 